### PR TITLE
Add vertical ripple frequency control

### DIFF
--- a/models/colab/ripple_texture_colab.ipynb
+++ b/models/colab/ripple_texture_colab.ipynb
@@ -13,7 +13,13 @@
     "\n",
     "if you change one of the code cells, make sure you run it and all subsequent cells again (in order)\n",
     "\n",
-    "*this document is a jupyter notebook - if they're new to you, check out how they work: [link](https://www.google.com/search?q=ipynb+tutorial), [link](https://jupyter.org/try-jupyter/retro/notebooks/?path=notebooks/Intro.ipynb), [link](https://colab.research.google.com/)*\n### be patient :)\n\nthe next code cell may take a while because running it causes several things to happen:\n- connect to a google colab server -> download the fullcontrol code -> install the fullcontrol code\n\ncheck out [other tutorials](https://github.com/FullControlXYZ/fullcontrol/blob/master/tutorials/README.md) to understand the python code for the FullControl design"
+    "*this document is a jupyter notebook - if they're new to you, check out how they work: [link](https://www.google.com/search?q=ipynb+tutorial), [link](https://jupyter.org/try-jupyter/retro/notebooks/?path=notebooks/Intro.ipynb), [link](https://colab.research.google.com/)*\n",
+    "### be patient :)\n",
+    "\n",
+    "the next code cell may take a while because running it causes several things to happen:\n",
+    "- connect to a google colab server -> download the fullcontrol code -> install the fullcontrol code\n",
+    "\n",
+    "check out [other tutorials](https://github.com/FullControlXYZ/fullcontrol/blob/master/tutorials/README.md) to understand the python code for the FullControl design"
    ]
   },
   {
@@ -22,7 +28,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if 'google.colab' in str(get_ipython()):\n  !pip install git+https://github.com/FullControlXYZ/fullcontrol --quiet\nimport fullcontrol as fc\nfrom google.colab import files\n",
+    "if 'google.colab' in str(get_ipython()):\n",
+    "  !pip install git+https://github.com/FullControlXYZ/fullcontrol --quiet\n",
+    "import fullcontrol as fc\n",
+    "from google.colab import files\n",
     "from math import cos, tau, sin\n",
     "from copy import deepcopy"
    ]
@@ -93,6 +102,8 @@
     "\n",
     "vert_rip_amp = 0.4\n",
     "# Vertical Ripple Amplitude (mm) - wave height along z for non-planar layers. Peaks align with horizontal ripples\n",
+    "vert_ripples_per_layer = ripples_per_layer\n",
+    "# Vertical Ripples Per Layer - Number of up-down waves along z for each layer\n",
     "\n",
     "RippleSegs = 2 # 2 means the ripple is zig-zag. increase this value to create a smooth wave, but watch out since the generation time will increase\n",
     "first_layer_E_factor = 0.4 # set to be 1 to double extrusion by the end of the layer, 0.4 adds 40%, which seemed good for me\n",
@@ -129,7 +140,7 @@
     "    r_now = inner_rad + rip_depth*(0.5+(0.5*cos((ripples_per_layer+0.5)*(t_val*tau))))**1 + \\\n",
     "        (tip_length*(0.5-0.5*cos(star_tips*(t_val*tau)))**shape_factor) + \\\n",
     "        (bulge*(sin((centre_now.z/height)*(0.5*tau))))\n",
-    "    centre_now.z = t_val*EH + vert_rip_amp*cos((ripples_per_layer+0.5)*(t_val*tau))\n",
+    "    centre_now.z = t_val*EH + vert_rip_amp*cos((vert_ripples_per_layer+0.5)*(t_val*tau))\n",
     "    if t_val < 1: # 1st layer\n",
     "        steps.append(fc.ExtrusionGeometry(height=EH+EH*t_val*first_layer_E_factor)) # ramp up extrusion during the first layer since vase mode means the nozzle moves away from the buildplate\n",
     "    if t_val == 1: # other layers\n",
@@ -178,7 +189,9 @@
     "        'fan_percent': fan_percent,\n",
     "        'extrusion_width': EW,\n",
     "        'extrusion_height': EH})\n",
-    "gcode = fc.transform(steps, 'gcode', gcode_controls)\nopen(f'{design_name}.gcode', 'w').write(gcode)\nfiles.download(f'{design_name}.gcode')"
+    "gcode = fc.transform(steps, 'gcode', gcode_controls)\n",
+    "open(f'{design_name}.gcode', 'w').write(gcode)\n",
+    "files.download(f'{design_name}.gcode')"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add `vert_ripples_per_layer` parameter in `ripple_texture_colab.ipynb`
- use new parameter when calculating vertical ripple motion

## Testing
- `pytest -q` *(fails: Kaleido requires Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6881851c5e6c832ea101557ccf7421ec