### PR TITLE
Add chicken wire fence demo

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -11,6 +11,7 @@ parametric models and a design template ([also available in colab](https://colab
     - [blob printing](https://fullcontrol.xyz/#/models/800020)  - [open in colab](https://colab.research.google.com/github/FullControlXYZ/fullcontrol/blob/master/models/colab/blob_printing_colab.ipynb)
     - [nuts_and_bolts](https://fullcontrol.xyz/#/models/393a4c)  - [open in colab](https://colab.research.google.com/github/FullControlXYZ/fullcontrol/blob/master/models/colab/nuts_and_bolts_colab.ipynb)
     - wavy woven vase - [open in colab](https://colab.research.google.com/github/FullControlXYZ/fullcontrol/blob/master/models/colab/wavy_woven_vase_colab.ipynb)
+    - chicken wire fence - [open in colab](https://colab.research.google.com/github/FullControlXYZ/fullcontrol/blob/master/models/colab/chicken_wire_fence_colab.ipynb)
     - [lampshade](https://fullcontrol.xyz/#/models/ebdc86)  - [open in colab](https://colab.research.google.com/gist/fullcontrol-xyz/589c78de0093698a07ec724af6428f09/fullcontrol-lampshade.ipynb)
 
 more designs are available on the fullcontrol [gists page](https://gist.github.com/fullcontrol-xyz)

--- a/models/chicken_wire_fence.ipynb
+++ b/models/chicken_wire_fence.ipynb
@@ -1,0 +1,172 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# chicken wire fence demo\n",
+    "\n",
+    "*<<< check out other demo models [here](https://github.com/FullControlXYZ/fullcontrol/tree/master/models/README.md) >>>*\n",
+    "  \n",
+    "run all cells in this notebook, or press shift+enter to run each cell sequentially \n",
+    "\n",
+    "if you change one of the code cells, make sure you run it and all subsequent cells again (in order)\n",
+    "\n",
+    "*this document is a jupyter notebook - if they're new to you, check out how they work: [link](https://www.google.com/search?q=ipynb+tutorial), [link](https://jupyter.org/try-jupyter/retro/notebooks/?path=notebooks/Intro.ipynb), [link](https://colab.research.google.com/)*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import fullcontrol as fc\n",
+    "import math\n",
+    "from math import cos, tau, sin\n",
+    "from copy import deepcopy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# printer/gcode parameters\n",
+    "\n",
+    "design_name = 'chicken_wire_fence'\n",
+    "nozzle_temp = 210\n",
+    "bed_temp = 40\n",
+    "print_speed = 500\n",
+    "fan_percent = 100\n",
+    "printer_name='prusa_i3' # generic / ultimaker2plus / prusa_i3 / ender_3 / cr_10 / bambulab_x1 / toolchanger_T0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# design parameters\n",
+    "\n",
+    "hex_radius = 5\n",
+    "rows = 5\n",
+    "cols = 5\n",
+    "layers = 2\n",
+    "nozzle_dia = 0.8\n",
+    "centre_x, centre_y = 50, 50\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# generate the design (make sure you've run the above cells before running this cell)\n",
+    "\n",
+    "EW = nozzle_dia*2.5\n",
+    "EH = nozzle_dia*0.6\n",
+    "steps = []\n",
+    "for row in range(rows):\n",
+    "    for col in range(cols):\n",
+    "        cx = col*1.5*hex_radius\n",
+    "        cy = row*math.sqrt(3)*hex_radius + (col%2)*(math.sqrt(3)/2*hex_radius)\n",
+    "        steps.extend(fc.polygonXY(fc.Point(x=cx, y=cy, z=0), hex_radius, tau/6, 6))\n",
+    "\n",
+    "steps = fc.move(steps, fc.Vector(z=EH), True, layers)\n",
+    "model_offset = fc.Vector(x=centre_x, y=centre_y, z=0.8*EH)\n",
+    "steps = fc.move(steps, model_offset)\n",
+    "annotation_pts = []\n",
+    "annotation_labels = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# preview the design\n",
+    "\n",
+    "# fc.transform(steps, 'plot', fc.PlotControls(zoom=0.4, style='line'))\n",
+    "# hover the cursor over the lines in the plot to check xyz positions of the points in the design\n",
+    "\n",
+    "# uncomment the next line to create a plot with real heights/widths for extruded lines to preview the real 3D printed geometry\n",
+    "fc.transform(steps, 'plot', fc.PlotControls(zoom=0.4, style='tube', initialization_data={'extrusion_width': EW, 'extrusion_height': EH}))\n",
+    "\n",
+    "# uncomment the next line to create a neat preview (click the top-left button in the plot for a .png file) - post and tag @FullControlXYZ :)\n",
+    "# fc.transform(steps, 'plot', fc.PlotControls(neat_for_publishing=True, zoom=0.4,  initialization_data={'extrusion_width': EW, 'extrusion_height': EH}))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# generate and save gcode\n",
+    "\n",
+    "gcode_controls = fc.GcodeControls(\n",
+    "    printer_name=printer_name,\n",
+    "    save_as=design_name,\n",
+    "    initialization_data={\n",
+    "        'primer': 'front_lines_then_y',\n",
+    "        'print_speed': print_speed,\n",
+    "        'nozzle_temp': nozzle_temp,\n",
+    "        'bed_temp': bed_temp,\n",
+    "        'fan_percent': fan_percent,\n",
+    "        'extrusion_width': EW,\n",
+    "        'extrusion_height': EH})\n",
+    "gcode = fc.transform(steps, 'gcode', gcode_controls)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### please tell us what you're doing with FullControl!\n",
+    "\n",
+    "- tag FullControlXYZ on social media ([twitter](https://twitter.com/FullControlXYZ), [instagram](https://www.instagram.com/fullcontrolxyz/), [linkedin](https://www.linkedin.com/in/andrew-gleadall-068587119/), [tiktok](https://www.tiktok.com/@fullcontrolxyz))\n",
+    "- email [info@fullcontrol.xyz](mailto:info@fullcontrol.xyz)\n",
+    "- post on the [subreddit](https://reddit.com/r/fullcontrol)\n",
+    "- post in the [github discussions or issues tabs](https://github.com/FullControlXYZ/fullcontrol/issues)\n",
+    "\n",
+    "in publications, please cite the original FullControl paper and the github repo for the new python version:\n",
+    "\n",
+    "- Gleadall, A. (2021). FullControl GCode Designer: open-source software for unconstrained design in additive manufacturing. Additive Manufacturing, 46, 102109. \n",
+    "- Gleadall, A. and Leas, D. (2023). FullControl [electronic resource: python source code]. available at: https://github.com/FullControlXYZ/fullcontrol"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "2b13a99eb0d91dd901c683fa32c6210ac0c6779bab056ce7c570b3b366dfe237"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/models/colab/chicken_wire_fence_colab.ipynb
+++ b/models/colab/chicken_wire_fence_colab.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# chicken wire fence demo\n",
+    "\n",
+    "*<<< check out other demo models [here](https://github.com/FullControlXYZ/fullcontrol/tree/master/models/README.md) >>>*\n",
+    "  \n",
+    "press ctrl+F9 to run all cells in this notebook, or press shift+enter to run each cell sequentially \n",
+    "\n",
+    "if you change one of the code cells, make sure you run it and all subsequent cells again (in order)\n",
+    "\n",
+    "*this document is a jupyter notebook - if they're new to you, check out how they work: [link](https://www.google.com/search?q=ipynb+tutorial), [link](https://jupyter.org/try-jupyter/retro/notebooks/?path=notebooks/Intro.ipynb), [link](https://colab.research.google.com/)*\n",
+    "### be patient :)\n",
+    "\n",
+    "the next code cell may take a while because running it causes several things to happen:\n",
+    "- connect to a google colab server -> download the fullcontrol code -> install the fullcontrol code\n",
+    "\n",
+    "check out [other tutorials](https://github.com/FullControlXYZ/fullcontrol/blob/master/tutorials/README.md) to understand the python code for the FullControl design"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if 'google.colab' in str(get_ipython()):\n",
+    "  !pip install git+https://github.com/FullControlXYZ/fullcontrol --quiet\n",
+    "import fullcontrol as fc\n",
+    "import math\n",
+    "from google.colab import files\n",
+    "from math import cos, tau, sin\n",
+    "from copy import deepcopy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# printer/gcode parameters\n",
+    "\n",
+    "design_name = 'chicken_wire_fence'\n",
+    "nozzle_temp = 210\n",
+    "bed_temp = 40\n",
+    "print_speed = 500\n",
+    "fan_percent = 100\n",
+    "printer_name='prusa_i3' # generic / ultimaker2plus / prusa_i3 / ender_3 / cr_10 / bambulab_x1 / toolchanger_T0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# design parameters\n",
+    "\n",
+    "hex_radius = 5\n",
+    "rows = 5\n",
+    "cols = 5\n",
+    "layers = 2\n",
+    "nozzle_dia = 0.8\n",
+    "centre_x, centre_y = 50, 50\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# generate the design (make sure you've run the above cells before running this cell)\n",
+    "\n",
+    "EW = nozzle_dia*2.5\n",
+    "EH = nozzle_dia*0.6\n",
+    "steps = []\n",
+    "for row in range(rows):\n",
+    "    for col in range(cols):\n",
+    "        cx = col*1.5*hex_radius\n",
+    "        cy = row*math.sqrt(3)*hex_radius + (col%2)*(math.sqrt(3)/2*hex_radius)\n",
+    "        steps.extend(fc.polygonXY(fc.Point(x=cx, y=cy, z=0), hex_radius, tau/6, 6))\n",
+    "\n",
+    "steps = fc.move(steps, fc.Vector(z=EH), True, layers)\n",
+    "model_offset = fc.Vector(x=centre_x, y=centre_y, z=0.8*EH)\n",
+    "steps = fc.move(steps, model_offset)\n",
+    "annotation_pts = []\n",
+    "annotation_labels = []\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# preview the design\n",
+    "\n",
+    "# fc.transform(steps, 'plot', fc.PlotControls(zoom=0.4, style='line'))\n",
+    "# hover the cursor over the lines in the plot to check xyz positions of the points in the design\n",
+    "\n",
+    "# uncomment the next line to create a plot with real heights/widths for extruded lines to preview the real 3D printed geometry\n",
+    "fc.transform(steps, 'plot', fc.PlotControls(zoom=0.4, style='tube', initialization_data={'extrusion_width': EW, 'extrusion_height': EH}))\n",
+    "\n",
+    "# uncomment the next line to create a neat preview (click the top-left button in the plot for a .png file) - post and tag @FullControlXYZ :)\n",
+    "# fc.transform(steps, 'plot', fc.PlotControls(neat_for_publishing=True, zoom=0.4,  initialization_data={'extrusion_width': EW, 'extrusion_height': EH}))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# generate and save gcode\n",
+    "\n",
+    "gcode_controls = fc.GcodeControls(\n",
+    "    printer_name=printer_name,\n",
+    "\n",
+    "    initialization_data={\n",
+    "        'primer': 'front_lines_then_y',\n",
+    "        'print_speed': print_speed,\n",
+    "        'nozzle_temp': nozzle_temp,\n",
+    "        'bed_temp': bed_temp,\n",
+    "        'fan_percent': fan_percent,\n",
+    "        'extrusion_width': EW,\n",
+    "        'extrusion_height': EH})\n",
+    "gcode = fc.transform(steps, 'gcode', gcode_controls)\n",
+    "open(f'{design_name}.gcode', 'w').write(gcode)\n",
+    "files.download(f'{design_name}.gcode')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### please tell us what you're doing with FullControl!\n",
+    "\n",
+    "- tag FullControlXYZ on social media ([twitter](https://twitter.com/FullControlXYZ), [instagram](https://www.instagram.com/fullcontrolxyz/), [linkedin](https://www.linkedin.com/in/andrew-gleadall-068587119/), [tiktok](https://www.tiktok.com/@fullcontrolxyz))\n",
+    "- email [info@fullcontrol.xyz](mailto:info@fullcontrol.xyz)\n",
+    "- post on the [subreddit](https://reddit.com/r/fullcontrol)\n",
+    "- post in the [github discussions or issues tabs](https://github.com/FullControlXYZ/fullcontrol/issues)\n",
+    "\n",
+    "in publications, please cite the original FullControl paper and the github repo for the new python version:\n",
+    "\n",
+    "- Gleadall, A. (2021). FullControl GCode Designer: open-source software for unconstrained design in additive manufacturing. Additive Manufacturing, 46, 102109. \n",
+    "- Gleadall, A. and Leas, D. (2023). FullControl [electronic resource: python source code]. available at: https://github.com/FullControlXYZ/fullcontrol"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "2b13a99eb0d91dd901c683fa32c6210ac0c6779bab056ce7c570b3b366dfe237"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- add `chicken_wire_fence.ipynb` for running outside Colab
- include chicken wire fence entry in models README
- fix missing `math` import in the Colab notebook

## Testing
- `pip install jupyter --quiet`
- `pip install Pillow --quiet`
- `pip install -e . --quiet`
- `pip install kaleido --quiet`
- `cd bin && python tutorials_to_py.py`
- `cd tests && pytest -q` *(fails: Kaleido requires additional system packages)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6882b340d94c832eb1b5a71ca7333a69