### PR TITLE
Improve fill_base_full documentation

### DIFF
--- a/lab/fullcontrol/geometry/fill.py
+++ b/lab/fullcontrol/geometry/fill.py
@@ -54,7 +54,12 @@ def fill_base_simple(steps: list, segments_per_layer: int, solid_layers: int, ex
 
 
 def fill_base_full(steps: list, segments_per_layer: int, solid_layers: int, extrusion_width: float):
-    'see fill_base_simple for an explanation of how this work'
+    '''see fill_base_simple for an explanation of how this work
+
+    The provided ``steps`` list should contain exactly one ``Point`` per
+    segment and no other step types. Supplying non-``Point`` steps may cause
+    misalignment or errors.
+    '''
     new_steps = []
     for i in range(len(steps)):
         t_val = i/segments_per_layer  # tval = 0 to layers


### PR DESCRIPTION
## Summary
- document that fill_base_full expects only Point steps for each segment
- warn that other step types may cause misalignment or errors

## Testing
- `pytest -q` *(fails: KeyboardInterrupt while running tests requiring Chrome via kaleido)*

------
https://chatgpt.com/codex/tasks/task_e_6887bad3b948832ebea51c488fe24da7