### PR TITLE
Validate steps list in fill utilities

### DIFF
--- a/lab/fullcontrol/geometry/fill.py
+++ b/lab/fullcontrol/geometry/fill.py
@@ -2,6 +2,27 @@ from fullcontrol import Point, polar_to_point, point_to_polar, BoundingBox, Vect
 from lab.fullcontrol.geometry.convex import convex_pathsXY
 
 
+def _validate_points(steps: list) -> None:
+    """Ensure all elements of ``steps`` are :class:`Point` objects.
+
+    Parameters
+    ----------
+    steps : list
+        List to validate.
+
+    Raises
+    ------
+    TypeError
+        If any element is not a ``Point`` instance.
+    """
+    for i, step in enumerate(steps):
+        if not isinstance(step, Point):
+            raise TypeError(
+                "steps must contain only Point objects for layer detection; "
+                f"found {type(step).__name__} at index {i}"
+            )
+
+
 # necessary functions
 def create_solid_layer(outline: list, extrusion_width: float, z_height: float):
     ''' create a solid layer by offsetting the outline inwards by 0.25*extrusion_width, then
@@ -39,7 +60,13 @@ def fill_base_simple(steps: list, segments_per_layer: int, solid_layers: int, ex
     are similar. If the outline is changing a lot over the first few layers, use fill_base_full instead, 
     which finds the outline for each solid layer and used that to create the solid fill using the convex 
     function for each new outline.
+
+    Raises
+    ------
+    TypeError
+        If any element in ``steps`` is not a :class:`Point`.
     '''
+    _validate_points(steps)
     first_layer_points = steps[:segments_per_layer+1]
     solid_layer = create_solid_layer(first_layer_points, extrusion_width, 0)
     new_steps = []
@@ -57,9 +84,10 @@ def fill_base_full(steps: list, segments_per_layer: int, solid_layers: int, extr
     '''see fill_base_simple for an explanation of how this work
 
     The provided ``steps`` list should contain exactly one ``Point`` per
-    segment and no other step types. Supplying non-``Point`` steps may cause
-    misalignment or errors.
+    segment and no other step types. Supplying non-``Point`` steps will raise
+    a ``TypeError``.
     '''
+    _validate_points(steps)
     new_steps = []
     for i in range(len(steps)):
         t_val = i/segments_per_layer  # tval = 0 to layers

--- a/tests/test_fill_validation.py
+++ b/tests/test_fill_validation.py
@@ -1,0 +1,22 @@
+import pytest
+from lab.fullcontrol.geometry.fill import fill_base_simple, fill_base_full
+from fullcontrol import Point
+
+
+def test_fill_base_simple_requires_points():
+    steps = [Point(x=0, y=0, z=0), "bad", Point(x=1, y=1, z=0)]
+    with pytest.raises(TypeError):
+        fill_base_simple(steps, segments_per_layer=1, solid_layers=1, extrusion_width=0.4)
+
+
+def test_fill_base_full_requires_points():
+    steps = [Point(x=0, y=0, z=0), "bad", Point(x=1, y=1, z=0)]
+    with pytest.raises(TypeError):
+        fill_base_full(steps, segments_per_layer=1, solid_layers=1, extrusion_width=0.4)
+
+
+def test_fill_base_simple_all_points():
+    steps = [Point(x=0, y=0, z=0), Point(x=1, y=0, z=0), Point(x=2, y=0, z=0)]
+    result = fill_base_simple(steps, segments_per_layer=1, solid_layers=0, extrusion_width=0.4)
+    assert len(result) == len(steps)
+


### PR DESCRIPTION
## Summary
- ensure `fill_base_simple` and `fill_base_full` only process `Point` steps
- document new validation
- test the validation logic

## Testing
- `PYTHONPATH=. pytest tests/test_fill_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887bc7836a8832ea3f32faf1eca31b1