### PR TITLE
Add U-shaped ripple pattern notebook variant

### DIFF
--- a/models/colab/ripple_texture_colab_filled_v07_pt2.ipynb
+++ b/models/colab/ripple_texture_colab_filled_v07_pt2.ipynb
@@ -1,0 +1,374 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "s2klBYSOq9Op"
+   },
+   "source": [
+    "# ripple texture demo\n",
+    "\n",
+    "*<<< check out other demo models [here](https://github.com/FullControlXYZ/fullcontrol/tree/master/models/README.md) >>>*\n",
+    "  \n",
+    "press ctrl+F9 to run all cells in this notebook, or press shift+enter to run each cell sequentially\n",
+    "\n",
+    "if you change one of the code cells, make sure you run it and all subsequent cells again (in order)\n",
+    "\n",
+    "*this document is a jupyter notebook - if they're new to you, check out how they work: [link](https://www.google.com/search?q=ipynb+tutorial), [link](https://jupyter.org/try-jupyter/retro/notebooks/?path=notebooks/Intro.ipynb), [link](https://colab.research.google.com/)*\n",
+    "### be patient :)\n",
+    "\n",
+    "the next code cell may take a while because running it causes several things to happen:\n",
+    "- connect to a google colab server -> download the fullcontrol code -> install the fullcontrol code\n",
+    "\n",
+    "check out [other tutorials](https://github.com/FullControlXYZ/fullcontrol/blob/master/tutorials/README.md) to understand the python code for the FullControl design"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ZoDPXmIgq9Oq",
+    "outputId": "7af0ef16-eb4e-468d-d3e4-c9326a7f8a40"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+      "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+      "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n"
+     ]
+    }
+   ],
+   "source": [
+    "if 'google.colab' in str(get_ipython()):\n",
+    "  get_ipython().system('pip install git+https://github.com/ChrisKeeleyGitHub/fullcontrol --quiet')\n",
+    "import fullcontrol as fc\n",
+    "try:\n",
+    "    from google.colab import files\n",
+    "except ImportError:\n",
+    "    files = None\n",
+    "from math import cos, tau, sin\n",
+    "from copy import deepcopy\n",
+    "import lab.fullcontrol as fclab\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {
+    "id": "PEhykZGWq9Or"
+   },
+   "outputs": [],
+   "source": [
+    "# printer/gcode parameters\n",
+    "\n",
+    "design_name = 'ripples'\n",
+    "nozzle_temp = 200\n",
+    "bed_temp = 0\n",
+    "print_speed = 500\n",
+    "fan_percent = 100\n",
+    "printer_name='prusa_i3' # generic / ultimaker2plus / prusa_i3 / ender_3 / cr_10 / bambulab_x1 / toolchanger_T0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "metadata": {
+    "id": "YLZAbh3Rq9Or"
+   },
+   "outputs": [],
+   "source": [
+    "# design parameters\n",
+    "\n",
+    "inner_rad= 40\n",
+    "# Inner Radius (mm) - Radius of the inner circle - 'star tip' and 'bulge' parameters morph the geometry radially outwards from this value\n",
+    "# default value: 15 ; guideline range: 10 to 30\n",
+    "\n",
+    "height = 40\n",
+    "# Height (mm) - Height of the part\n",
+    "# default value: 40 ; guideline range: 20 to 80\n",
+    "\n",
+    "skew_percent = 10\n",
+    "# Twist (%) - How much does the structure twist over its height? 100% means one full rotation anti-clockwise\n",
+    "# default value: 10 ; guideline range: -100 to 100\n",
+    "\n",
+    "star_tips = 0\n",
+    "# Star Tips - The number of outward protrusions from a nominally circular geometry - to make a star-like shape\n",
+    "# default value: 4 ; guideline range: 0 to 10\n",
+    "\n",
+    "tip_length = 10\n",
+    "# Star Tip Length (mm) - How much does each 'star tip' protrude beyond the inner radius?\n",
+    "# default value: 5 ; guideline range: -20 to 20\n",
+    "\n",
+    "bulge = 10\n",
+    "# Bulge (mm) - The geometry bulges out by this amount half way up the structure\n",
+    "# default value: 2 ; guideline range: -20 to 20\n",
+    "\n",
+    "nozzle_dia = 0.8\n",
+    "# Nozzle Diameter (mm) - This is used to set a reasonable value for layer height and extrusion rate\n",
+    "# default value: 0.4 ; guideline range: 0.3 to 1.2\n",
+    "\n",
+    "ripples_per_layer = 20\n",
+    "# Ripples Per Layer - Number of in-out waves the nozzle performs for each layer. There is actually an extra half-ripple for each layer so that the ripples are offset for each alternating layer\n",
+    "# default value: 50 ; guideline range: 20 to 100\n",
+    "\n",
+    "rip_depth = 1.6\n",
+    "# Ripple Depth (mm) - How far the nozzle moves in and out radially for each 'ripple'\n",
+    "# default value: 1 ; guideline range: 0 to 5\n",
+    "\n",
+    "shape_factor = 1.25\n",
+    "# Start Tip Pointiness - This affects how pointy the 'star tips' are and can achieve very interesting geometries\n",
+    "# default value: 1.5 ; guideline range: 0.25 to 5\n",
+    "\n",
+    "vert_rip_amp = 0.8\n",
+    "\n",
+    "vert_ripples_per_layer = 20\n",
+    "# Vertical Ripples Per Layer - Number of vertical waves per layer\n",
+    "# default value: 1 ; guideline range: 0 to 10\n",
+    "\n",
+    "use_sine_squared = True\n",
+    "# Use Sine Squared - If True, vertical ripple waves use a sine-squared shape\n",
+    "# default value: False\n",
+    "# Vertical Ripple Amplitude (mm) - wave height along z for non-planar layers. Peaks align with horizontal ripples\n",
+    "\n",
+    "RippleSegs = 200 # 2 means the ripple is zig-zag. increase this value to create a smooth wave, but watch out since the generation time will increase\n",
+    "first_layer_E_factor = 0.4 # set to be 1 to double extrusion by the end of the layer, 0.4 adds 40%, which seemed good for me\n",
+    "centre_x, centre_y = 50, 50"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "2q8_ULN3q9Os",
+    "outputId": "f6603a88-dbb2-475a-b0ec-a80234226925"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "yay! CONVEX function used :) please cite our CONVEX research study: https://www.researchgate.net/publication/346098541\n"
+     ]
+    }
+   ],
+   "source": [
+    "# generate the design (make sure you've run the above cells before running this cell)\n",
+    "\n",
+    "EW = nozzle_dia*2.5\n",
+    "EH = nozzle_dia*0.6\n",
+    "centre = fc.Point(x=50, y=50, z=-1.5)\n",
+    "centre_now = deepcopy(centre)\n",
+    "layers = int(height/EH)\n",
+    "layer_segs = (ripples_per_layer+0.5)*RippleSegs\n",
+    "total_segs = layer_segs*layers\n",
+    "\n",
+    "# offset the whole procedure to a convenient position on the print bed. initial_z dictates the gap between the nozzle and the bed for the first layer, assuming the model was designed with a first layer z-position of 0\n",
+    "initial_z = 0.8*EH + vert_rip_amp -3\n",
+    "model_offset = fc.Vector(x=centre_x, y=centre_y, z=initial_z)\n",
+    "\n",
+    "steps = []\n",
+    "points = []\n",
+    "\n",
+    "def u_shape(center, width, height, segs):\n",
+    "    pts = [fc.Point(x=center.x, y=center.y, z=center.z)]\n",
+    "    # move up\n",
+    "    pts.append(fc.Point(x=center.x, y=center.y + height, z=center.z))\n",
+    "    # arc over top\n",
+    "    for s in range(segs + 1):\n",
+    "        a = (tau/2) - (tau/2)*s/segs\n",
+    "        x = center.x + width * (1 - cos(a))\n",
+    "        y = center.y + height + width * sin(a)\n",
+    "        pts.append(fc.Point(x=x, y=y, z=center.z))\n",
+    "    # descend\n",
+    "    pts.append(fc.Point(x=center.x + 2*width, y=center.y, z=center.z))\n",
+    "    return pts\n",
+    "\n",
+    "u_width = EW\n",
+    "u_height = rip_depth\n",
+    "start_x = centre.x - ripples_per_layer*1.5*u_width/2\n",
+    "for i in range(ripples_per_layer):\n",
+    "    centre_now.x = start_x + i*1.5*u_width\n",
+    "    centre_now.y = centre.y\n",
+    "    points.extend(u_shape(centre_now, u_width, u_height, RippleSegs))\n",
+    "\n",
+    "steps.extend(fclab.fill_base_full(points, int(layer_segs), 1, EW))\n",
+    "steps = fc.move(steps, model_offset)\n",
+    "annotation_pts = []\n",
+    "annotation_labels = []\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "loHI9qcnq9Os"
+   },
+   "outputs": [],
+   "source": [
+    "# preview the design\n",
+    "\n",
+    "# fc.transform(steps, 'plot', fc.PlotControls(zoom=0.4, style='line'))\n",
+    "# hover the cursor over the lines in the plot to check xyz positions of the points in the design\n",
+    "\n",
+    "# uncomment the next line to create a plot with real heights/widths for extruded lines to preview the real 3D printed geometry\n",
+    "fc.transform(steps, 'plot', fc.PlotControls(zoom=0.4, style='tube', initialization_data={'extrusion_width': EW, 'extrusion_height': EH}))\n",
+    "\n",
+    "# uncomment the next line to create a neat preview (click the top-left button in the plot for a .png file) - post and tag @FullControlXYZ :)\n",
+    "# fc.transform(steps, 'plot', fc.PlotControls(neat_for_publishing=True, zoom=0.4,  initialization_data={'extrusion_width': EW, 'extrusion_height': EH}))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 17
+    },
+    "id": "38o4Q9Xzq9Ot",
+    "outputId": "489591ea-1bd6-4731-9acc-2dd1794d30e3"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "    async function download(id, filename, size) {\n",
+       "      if (!google.colab.kernel.accessAllowed) {\n",
+       "        return;\n",
+       "      }\n",
+       "      const div = document.createElement('div');\n",
+       "      const label = document.createElement('label');\n",
+       "      label.textContent = `Downloading \"${filename}\": `;\n",
+       "      div.appendChild(label);\n",
+       "      const progress = document.createElement('progress');\n",
+       "      progress.max = size;\n",
+       "      div.appendChild(progress);\n",
+       "      document.body.appendChild(div);\n",
+       "\n",
+       "      const buffers = [];\n",
+       "      let downloaded = 0;\n",
+       "\n",
+       "      const channel = await google.colab.kernel.comms.open(id);\n",
+       "      // Send a message to notify the kernel that we're ready.\n",
+       "      channel.send({})\n",
+       "\n",
+       "      for await (const message of channel.messages) {\n",
+       "        // Send a message to notify the kernel that we're ready.\n",
+       "        channel.send({})\n",
+       "        if (message.buffers) {\n",
+       "          for (const buffer of message.buffers) {\n",
+       "            buffers.push(buffer);\n",
+       "            downloaded += buffer.byteLength;\n",
+       "            progress.value = downloaded;\n",
+       "          }\n",
+       "        }\n",
+       "      }\n",
+       "      const blob = new Blob(buffers, {type: 'application/binary'});\n",
+       "      const a = document.createElement('a');\n",
+       "      a.href = window.URL.createObjectURL(blob);\n",
+       "      a.download = filename;\n",
+       "      div.appendChild(a);\n",
+       "      a.click();\n",
+       "      div.remove();\n",
+       "    }\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "download(\"download_87e49c5f-9a5d-492c-a5c7-a9499849b4e5\", \"ripples.gcode\", 18830804)"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# generate and save gcode\n",
+    "\n",
+    "gcode_controls = fc.GcodeControls(\n",
+    "    printer_name=printer_name,\n",
+    "\n",
+    "    initialization_data={\n",
+    "        'primer': 'front_lines_then_y',\n",
+    "        'print_speed': print_speed,\n",
+    "        'nozzle_temp': nozzle_temp,\n",
+    "        'bed_temp': bed_temp,\n",
+    "        'fan_percent': fan_percent,\n",
+    "        'extrusion_width': EW,\n",
+    "        'extrusion_height': EH})\n",
+    "gcode = fc.transform(steps, 'gcode', gcode_controls)\n",
+    "open(f'{design_name}.gcode', 'w').write(gcode)\n",
+    "files.download(f'{design_name}.gcode') if files else None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fubqFnsgq9Ot"
+   },
+   "source": [
+    "#### please tell us what you're doing with FullControl!\n",
+    "\n",
+    "- tag FullControlXYZ on social media ([twitter](https://twitter.com/FullControlXYZ), [instagram](https://www.instagram.com/fullcontrolxyz/), [linkedin](https://www.linkedin.com/in/andrew-gleadall-068587119/), [tiktok](https://www.tiktok.com/@fullcontrolxyz))\n",
+    "- email [info@fullcontrol.xyz](mailto:info@fullcontrol.xyz)\n",
+    "- post on the [subreddit](https://reddit.com/r/fullcontrol)\n",
+    "- post in the [github discussions or issues tabs](https://github.com/FullControlXYZ/fullcontrol/issues)\n",
+    "\n",
+    "in publications, please cite the original FullControl paper and the github repo for the new python version:\n",
+    "\n",
+    "- Gleadall, A. (2021). FullControl GCode Designer: open-source software for unconstrained design in additive manufacturing. Additive Manufacturing, 46, 102109.\n",
+    "- Gleadall, A. and Leas, D. (2023). FullControl [electronic resource: python source code]. available at: https://github.com/FullControlXYZ/fullcontrol"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "2b13a99eb0d91dd901c683fa32c6210ac0c6779bab056ce7c570b3b366dfe237"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary
- duplicate ripple texture notebook to _pt2 variant
- replace radial ripple generation with upside-down U-shaped pattern
- handle optional Google Colab imports for local execution

## Testing
- `jupyter nbconvert --to notebook --execute models/colab/ripple_texture_colab_filled_v07_pt2.ipynb --output ripple_texture_colab_filled_v07_pt2_executed.ipynb --output-dir models/colab`
- `pytest` *(fails: Kaleido requires Google Chrome to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a625415c90832e8f77d640d1d8e5af