### PR TITLE
Use polynomial arch wave in ripple texture model

### DIFF
--- a/fullcontrol/combinations/gcode_and_visualize/common.py
+++ b/fullcontrol/combinations/gcode_and_visualize/common.py
@@ -6,7 +6,18 @@ from typing import Union
 # import functions and classes that will be accessible to the user
 from .classes import *
 from fullcontrol.common import fix
-from fullcontrol.common import check, flatten, linspace, export_design, import_design, points_only, relative_point, first_point, last_point
+from fullcontrol.common import (
+    check,
+    flatten,
+    linspace,
+    export_design,
+    import_design,
+    points_only,
+    relative_point,
+    first_point,
+    last_point,
+    poly_arch_wave,
+)
 from fullcontrol.geometry import *
 from fullcontrol.visualize.bounding_box import BoundingBox
 

--- a/fullcontrol/common.py
+++ b/fullcontrol/common.py
@@ -3,5 +3,15 @@ from fullcontrol.extrusion_classes import ExtrusionGeometry, StationaryExtrusion
 from fullcontrol.auxilliary_components import Fan, Hotend, Buildplate
 from fullcontrol.point import Point
 from fullcontrol.printer import Printer
-from fullcontrol.extra_functions import points_only, relative_point, flatten, linspace, first_point, last_point, export_design, import_design
+from fullcontrol.extra_functions import (
+    points_only,
+    relative_point,
+    flatten,
+    linspace,
+    poly_arch_wave,
+    first_point,
+    last_point,
+    export_design,
+    import_design,
+)
 from fullcontrol.check import check, fix, check_points

--- a/fullcontrol/extra_functions.py
+++ b/fullcontrol/extra_functions.py
@@ -112,6 +112,40 @@ def linspace(start: float, end: float, number_of_points: int) -> list:
     return [start + float(x)/(number_of_points-1)*(end-start) for x in range(number_of_points)]
 
 
+def poly_arch_wave(t, cycles, power, flat_ratio):
+    """Return an arch-shaped polynomial wave with a zero-valued flat interval.
+
+    Parameters
+    ----------
+    t : float or list-like
+        Input value(s) for evaluating the waveform.
+    cycles : int or float
+        Number of repeats per unit interval.
+    power : float
+        Exponent controlling arch sharpness.
+    flat_ratio : float
+        Fraction of each cycle held at zero.
+
+    Returns
+    -------
+    float or list
+        Normalized waveform values between 0 and 1.
+    """
+    def _single(x):
+        if flat_ratio >= 1:
+            return 0.0
+        pos = (x * cycles) % 1.0
+        if pos < flat_ratio:
+            return 0.0
+        active = 1.0 - flat_ratio
+        y = (pos - flat_ratio) / active
+        val = (1 - abs(2*y - 1)) ** power
+        return max(0.0, min(1.0, val))
+    if isinstance(t, (list, tuple)):
+        return [_single(float(v)) for v in t]
+    return _single(float(t))
+
+
 def first_point(steps: list, fully_defined: bool = True) -> Point:
     '''
     Return the first Point in the list.

--- a/models/ripple_texture.ipynb
+++ b/models/ripple_texture.ipynb
@@ -24,6 +24,7 @@
    "source": [
     "import fullcontrol as fc\n",
     "from math import cos, tau, sin\n",
+    "from fullcontrol.extra_functions import poly_arch_wave\n",
     "from copy import deepcopy"
    ]
   },
@@ -86,6 +87,14 @@
     "rip_depth = 2\n",
     "# Ripple Depth (mm) - How far the nozzle moves in and out radially for each 'ripple'\n",
     "# default value: 1 ; guideline range: 0 to 5\n",
+    "arch_power = 2\n",
+    "# Arch Power - Controls sharpness of ripple peaks using poly_arch_wave\n",
+    "# default value: 2 ; guideline range: 0.5 to 5\n",
+    "\n",
+    "flat_zero_ratio = 0\n",
+    "# Flat Zero Ratio - Fraction of each ripple cycle held at zero\n",
+    "# default value: 0 ; guideline range: 0 to 0.9\n",
+    "\n",
     "\n",
     "shape_factor = 1.5\n",
     "# Start Tip Pointiness - This affects how pointy the 'star tips' are and can achieve very interesting geometries\n",
@@ -126,7 +135,8 @@
     "    a_now = t_val*tau*(1+(skew_percent/100)/layers)\n",
     "    a_now -= tau/4 # make the print start from front middle (near primer line)\n",
     "    # the next equation (r_now) looks more complicated than it is. basically radius is inner_rad + radial fluctuation due to ripples (1st line) + radial fluctuation due to the star shape (2nd line) + radial fluctuation due to the bulge (3rd line)\n",
-    "    r_now = inner_rad + rip_depth*(0.5+(0.5*cos((ripples_per_layer+0.5)*(t_val*tau))))**1 + \\\n",
+    "    radial_wave = rip_depth * poly_arch_wave(t_val, ripples_per_layer + 0.5, arch_power, flat_zero_ratio)\n",
+    "    r_now = inner_rad + radial_wave + \\\n",
     "        (tip_length*(0.5-0.5*cos(star_tips*(t_val*tau)))**shape_factor) + \\\n",
     "        (bulge*(sin((centre_now.z/height)*(0.5*tau))))\n",
     "    centre_now.z = t_val*EH + vert_rip_amp*sin((ripples_per_layer+0.5)*(t_val*tau))\n",


### PR DESCRIPTION
## Summary
- add `poly_arch_wave` helper to extra functions and expose via common interfaces
- update ripple texture model to use `poly_arch_wave` and expose `arch_power` and `flat_zero_ratio` parameters

## Testing
- `pytest` *(fails: FileNotFoundError: No such file or directory: 'combined_tutorials.py')*

------
https://chatgpt.com/codex/tasks/task_e_68a74ffbd6cc832e9aa1cbb47caf26af